### PR TITLE
feat: enable automated releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,13 @@ repos:
       - id: prettier
         exclude: ^docs/api/python/
 
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.13.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]
+
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,25 +1,27 @@
 {
     "packages": {
-        ".": {
-            "changelog-path": "CHANGELOG.md",
+        "crates/ih-muse": {
             "release-type": "rust",
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
-            "draft": false,
-            "prerelease": false,
             "include-v-in-tag": true,
-            "tag-separator": "-v",
-            "extra-files": [
-                {
-                    "type": "toml",
-                    "path": "py-ih-muse/Cargo.toml",
-                    "jsonpath": "$.package.version"
-                },
-                {
-                    "type": "toml",
-                    "path": "crates/ih-muse-core/Cargo.toml",
-                    "jsonpath": "$.package.version"
-                }
+            "changelog-types": [
+                { "type": "feat", "section": "Features", "hidden": false },
+                { "type": "fix", "section": "Bug Fixes", "hidden": false },
+                { "type": "docs", "section": "Documentation", "hidden": false },
+                { "type": "perf", "section": "Performance", "hidden": false }
+            ]
+        },
+        "crates/ih-muse-core": {
+            "release-type": "rust",
+            "bump-minor-pre-major": true,
+            "bump-patch-for-minor-pre-major": true,
+            "include-v-in-tag": true,
+            "changelog-types": [
+                { "type": "feat", "section": "Features", "hidden": false },
+                { "type": "fix", "section": "Bug Fixes", "hidden": false },
+                { "type": "docs", "section": "Documentation", "hidden": false },
+                { "type": "perf", "section": "Performance", "hidden": false }
             ]
         }
     },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
 resolver = "2"
 
 default-members = [
+  "crates/ih-muse-core",
+  "crates/ih-muse",
   "crates/*",
 ]
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat", // New features
+        "fix", // Bug fixes
+        "docs", // Documentation only changes
+        "style", // Changes that do not affect the meaning of the code
+        "refactor", // A code change that neither fixes a bug nor adds a feature
+        "perf", // A code change that improves performance
+        "test", // Adding missing tests
+        "build", // Changes that affect the build system or external dependencies
+        "ci", // Changes to CI configuration files and scripts
+        "chore", // Other changes that don't modify src or test files
+        "revert", // Reverts a previous commit
+      ],
+    ],
+    "scope-case": [0],
+    "subject-case": [0],
+  },
+};


### PR DESCRIPTION
This commit adds support for automated releases with the following changes:
- Update version tags in Cargo.toml files
- Configure workspace members properly
- Set up release-please configuration