### PR TITLE
fix: type missmatch local element id on python

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,15 +22,19 @@ categories:
     labels:
       - "deps"
       - "dependencies"
+  - title: "📦 Miscellaneous"
+    labels: []
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 
 template: |
-  ## What's Changed
+  ## v$RESOLVED_VERSION - {{date}}
+
+  ### What's Changed
 
   $CATEGORIES
 
-  ## Contributors
+  ### Contributors
 
   $CONTRIBUTORS
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "chrono",
  "env_logger",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-cli"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-client"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-core"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-proto"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "chrono",
  "serde",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-python"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "chrono",
  "ih-muse",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "ih-muse-record"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "py-ih-muse"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "ih-muse-python",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.0.24"
+version = "0.0.25"
 edition = "2021"
 rust-version = "1.78"
 homepage = "https://infinitehaiku.com"
@@ -23,12 +23,12 @@ authors = ["Luis Diaz <code.luis.diaz@proton.me"]
 license = "MIT"
 
 [workspace.dependencies]
-ih-muse = { version = "0.0.24", path = "crates/ih-muse" }
-ih-muse-client = { version = "0.0.24", path = "crates/ih-muse-client" }
-ih-muse-core = { version = "0.0.24", path = "crates/ih-muse-core" }
-ih-muse-python = { version = "0.0.24", path = "crates/ih-muse-python" }
-ih-muse-proto = { version = "0.0.24", path = "crates/ih-muse-proto" }
-ih-muse-record = { version = "0.0.24", path = "crates/ih-muse-record" }
+ih-muse = { version = "0.0.25", path = "crates/ih-muse" }
+ih-muse-client = { version = "0.0.25", path = "crates/ih-muse-client" }
+ih-muse-core = { version = "0.0.25", path = "crates/ih-muse-core" }
+ih-muse-python = { version = "0.0.25", path = "crates/ih-muse-python" }
+ih-muse-proto = { version = "0.0.25", path = "crates/ih-muse-proto" }
+ih-muse-record = { version = "0.0.25", path = "crates/ih-muse-record" }
 
 async-trait = "0.1"
 chrono = "0.4.38"

--- a/crates/ih-muse-core/src/errors.rs
+++ b/crates/ih-muse-core/src/errors.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use chrono::OutOfRangeError;
 use thiserror::Error;
 
+use ih_muse_proto::prelude::*;
+
 pub type MuseResult<T> = Result<T, MuseError>;
 
 #[derive(Error, Debug)]
@@ -23,6 +25,8 @@ pub enum MuseError {
     InvalidFileExtension(Option<String>),
     #[error("Invalid Element Kind Code {0}")]
     InvalidElementKindCode(String),
+    #[error("Do not exists a remote element id for {0}")]
+    NotAvailableRemoteElementId(LocalElementId),
     #[error("Invalid Metric Code {0}")]
     InvalidMetricCode(String),
     #[error("Duration conversion error: {0}")]

--- a/crates/ih-muse-python/src/error.rs
+++ b/crates/ih-muse-python/src/error.rs
@@ -63,6 +63,9 @@ impl std::convert::From<PyMusesErr> for PyErr {
                 MuseError::InvalidElementKindCode(name) => {
                     InvalidElementKindCodeError::new_err(name.to_string())
                 }
+                MuseError::NotAvailableRemoteElementId(id) => {
+                    NotAvailableRemoteElementIdError::new_err(id.to_string())
+                }
                 MuseError::InvalidMetricCode(name) => {
                     InvalidMetricCodeError::new_err(name.to_string())
                 }

--- a/crates/ih-muse-python/src/exceptions.rs
+++ b/crates/ih-muse-python/src/exceptions.rs
@@ -15,5 +15,10 @@ create_exception!(ih_muse.exceptions, RecordingError, MuseError);
 create_exception!(ih_muse.exceptions, ReplayingError, MuseError);
 create_exception!(ih_muse.exceptions, InvalidFileExtensionError, MuseError);
 create_exception!(ih_muse.exceptions, InvalidElementKindCodeError, MuseError);
+create_exception!(
+    ih_muse.exceptions,
+    NotAvailableRemoteElementIdError,
+    MuseError
+);
 create_exception!(ih_muse.exceptions, InvalidMetricCodeError, MuseError);
 create_exception!(ih_muse.exceptions, DurationConversionError, MuseError);

--- a/crates/ih-muse-python/src/muse/general.rs
+++ b/crates/ih-muse-python/src/muse/general.rs
@@ -70,13 +70,17 @@ impl PyMuse {
         kind_code: &str,
         name: String,
         metadata: HashMap<String, String>,
-        parent_id: Option<u64>,
+        parent_id: Option<&str>,
         py: Python<'p>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let muse = self.muse.clone();
         let kind_code = kind_code.to_string();
         let name = name.clone();
         let metadata = metadata.clone();
+        let parent_id = parent_id
+            .map(LocalElementId::parse_str)
+            .transpose()
+            .map_err(PyMusesErr::from)?;
         future_into_py(py, async move {
             let muse_guard = muse.lock().await;
             let local_elem_id = muse_guard

--- a/crates/ih-muse-record/src/lib.rs
+++ b/crates/ih-muse-record/src/lib.rs
@@ -36,7 +36,7 @@ pub enum RecordedEvent {
         kind_code: String,
         name: String,
         metadata: HashMap<String, String>,
-        parent_id: Option<ElementId>,
+        parent_id: Option<LocalElementId>,
     },
     SendMetric {
         local_elem_id: LocalElementId,

--- a/py-ih-muse/ih_muse/exceptions.py
+++ b/py-ih-muse/ih_muse/exceptions.py
@@ -10,6 +10,7 @@ try:
         InvalidMetricCodeError,
         MuseError,
         MuseInitializationTimeoutError,
+        NotAvailableRemoteElementIdError,
         RecordingError,
         ReplayingError,
     )
@@ -47,6 +48,9 @@ except ImportError:
     class InvalidElementKindCodeError(MuseError):  # type: ignore[no-redef, misc]
         """TODO DOCS."""
 
+    class NotAvailableRemoteElementIdError(MuseError):  # type: ignore[no-redef, misc]
+        """TODO DOCS."""
+
     class InvalidMetricCodeError(MuseError):  # type: ignore[no-redef, misc]
         """TODO DOCS."""
 
@@ -65,6 +69,7 @@ __all__ = [
     "InvalidMetricCodeError",
     "MuseError",
     "MuseInitializationTimeoutError",
+    "NotAvailableRemoteElementIdError",
     "PanicException",
     "RecordingError",
     "ReplayingError",

--- a/py-ih-muse/ih_muse/ih_muse.pyi
+++ b/py-ih-muse/ih_muse/ih_muse.pyi
@@ -9,17 +9,17 @@ class PyMuse:
     is_initialized: bool
     finest_resolution: TimestampResolution
     async def initialize(self, timeout: Optional[float] = None) -> None: ...
-    def get_remote_element_id(self, local_elem_id: int) -> Optional[int]: ...
+    def get_remote_element_id(self, local_elem_id: str) -> Optional[int]: ...
     async def register_element(
         self,
         kind_code: str,
         name: str,
         metadata: dict[str, str],
-        parent_id: Optional[int] = None,
-    ) -> int: ...
+        parent_id: Optional[str] = None,
+    ) -> str: ...
     async def send_metric(
         self,
-        local_elem_id: int,
+        local_elem_id: str,
         metric_code: str,
         value: float,
     ) -> None: ...

--- a/py-ih-muse/ih_muse/muse/muse.py
+++ b/py-ih-muse/ih_muse/muse/muse.py
@@ -81,7 +81,7 @@ class Muse:
         """
         return self._muse.finest_resolution
 
-    def get_remote_element_id(self, local_elem_id: int) -> Optional[int]:
+    def get_remote_element_id(self, local_elem_id: str) -> Optional[int]:
         """Retrieve the remote Element ID associated with a local Element ID.
 
         :param str local_elem_id:
@@ -97,8 +97,8 @@ class Muse:
         kind_code: str,
         name: str,
         metadata: dict[str, str],
-        parent_id: Optional[int] = None,
-    ) -> int:
+        parent_id: Optional[str] = None,
+    ) -> str:
         """Register a new element with the Muse system.
 
         :param str kind_code:
@@ -126,7 +126,7 @@ class Muse:
 
     async def send_metric(
         self,
-        local_elem_id: int,
+        local_elem_id: str,
         metric_code: str,
         value: float,
     ) -> None:

--- a/py-ih-muse/pyproject.toml
+++ b/py-ih-muse/pyproject.toml
@@ -3,7 +3,7 @@
 [project]
 name = "ih-muse"
 # version = "0.0.1"
-# dynamic = ["version"]
+dynamic = ["version"]
 description = "Common muse library for python"
 authors = [{ name = "Luis Diaz" }]
 readme = "README.md"

--- a/py-ih-muse/src/lib.rs
+++ b/py-ih-muse/src/lib.rs
@@ -84,6 +84,11 @@ fn ih_muse(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     )
     .unwrap();
     m.add(
+        "NotAvailableRemoteElementIdError",
+        py.get_type_bound::<exceptions::NotAvailableRemoteElementIdError>(),
+    )
+    .unwrap();
+    m.add(
         "InvalidMetricCodeError",
         py.get_type_bound::<exceptions::InvalidMetricCodeError>(),
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -85,7 +85,7 @@ class MuseTestContext:
         endpoint = "http://localhost:8000"
         return cls(muse, endpoint)
 
-    async def register_test_element(self) -> int:
+    async def register_test_element(self) -> str:
         """Register a test element with the Muse system.
 
         This method registers an element with default parameters suitable for testing.


### PR DESCRIPTION
## 📝 Description

Uses Local Element Id to refer the parent id when register new elements, it will check for the remote id internally in the state cache.

Like that the recordings are coherent and the final library implementation does not require explicitly retrieving the remote id.

Fixes #26 